### PR TITLE
LIBDRUM-415. Vagrant-drum provisioning fails.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -3,7 +3,7 @@
 
 # Install Puppet PostgreSQL module from PuppetForge
 forge "http://forge.puppetlabs.com"
-mod "puppetlabs/postgresql", "3.3.0"
+mod "puppetlabs/postgresql", "3.4.0"
 mod "saz/vim"
 
 # we'll use Maestrodev's maven puppet modle to isntall Maven for us


### PR DESCRIPTION
Updated puppetlabs postgres version that was causing the failure.

https://issues.umd.edu/browse/LIBDRUM-415
